### PR TITLE
refactor: 💡 Update get_last_stable_release to use async iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 name = "canary-deployments-rs"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "octocrab",
  "regex",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.68"
 octocrab = "0.25.0"
 regex = "1.8.3"
 tokio = { version = "1.28.2", features = ["full"] }


### PR DESCRIPTION
Update the implementation of the get_last_stable_release function to use an async iterator. This change prevents overfetching and underfetching and reduces the likelihood of unexpected bugs.