### PR TITLE
fix: 🕰️ Format published_at in RFC 3339 format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ name = "canary-deployments-rs"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "octocrab",
  "regex",
  "tokio",
@@ -139,8 +140,11 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -493,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -906,7 +910,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.21",
 ]
 
 [[package]]
@@ -1003,6 +1007,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.18",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1245,6 +1260,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.68"
+chrono = "0.4.26"
 octocrab = "0.25.0"
 regex = "1.8.3"
 tokio = { version = "1.28.2", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::collections::HashSet;
 use std::env;
 use tokio;
+use chrono;
 
 struct Releases<'a> {
     octocrab: &'a Octocrab,
@@ -284,7 +285,8 @@ async fn create_canary_release(octocrab: &Octocrab) -> octocrab::Result<()> {
     }
 
     let published_at_string = if let Some(latest_release) = &latest_release {
-        latest_release.published_at.unwrap().to_string()
+        latest_release.published_at.unwrap().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+        .to_string()
     } else {
         "1970-01-01".to_string()
     };
@@ -376,7 +378,7 @@ async fn create_release(octocrab: &Octocrab) -> octocrab::Result<()> {
     let published_at_string = last_stable_release
         .map(|release| release.published_at)
         .unwrap_or_else(|| None)
-        .map(|d| d.to_rfc3339())
+        .map(|d| d.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
         .unwrap_or_else(|| "1970-01-01".to_string());
 
     let published_at = published_at_string.as_str();


### PR DESCRIPTION
Use the to_rfc3339_opts method from the chrono crate to format the published_at field of a latest_release object in RFC 3339 format with seconds precision.